### PR TITLE
Angular 1.5 components fixes + Base atoms for <h3> and <a> tags

### DIFF
--- a/lib/atoms/a/a.component.js
+++ b/lib/atoms/a/a.component.js
@@ -1,0 +1,13 @@
+var lnAA = {
+    templateUrl: 'lnPatterns/atoms/a/template.html',
+    bindings: {
+        link: '@',
+        href: '@',
+        target: '@',
+        class: '@'
+    }
+};
+
+angular
+    .module('lnPatterns')
+    .component('lnAA', lnAA);

--- a/lib/atoms/a/a.component.js
+++ b/lib/atoms/a/a.component.js
@@ -1,7 +1,7 @@
 var lnAA = {
     templateUrl: 'lnPatterns/atoms/a/template.html',
     bindings: {
-        link: '@',
+        title: '@',
         href: '@',
         target: '@',
         class: '@'

--- a/lib/atoms/a/example.html
+++ b/lib/atoms/a/example.html
@@ -1,0 +1,1 @@
+<ln-a-a link="{{link}}" href="{{href}}" target="{{target}}" class="{{class}}"></ln-a-a>

--- a/lib/atoms/a/example.html
+++ b/lib/atoms/a/example.html
@@ -1,1 +1,1 @@
-<ln-a-a link="{{link}}" href="{{href}}" target="{{target}}" class="{{class}}"></ln-a-a>
+<ln-a-a title="{{title}}" href="{{href}}" target="{{target}}" class="{{class}}"></ln-a-a>

--- a/lib/atoms/a/metadata.json
+++ b/lib/atoms/a/metadata.json
@@ -2,7 +2,7 @@
   "name": "ln-a-a",
   "description": "Atom - A Link",
   "params": {
-    "link": "STRING",
+    "title": "STRING",
     "href": "STRING",
     "target": "STRING",
     "class": "STRING"

--- a/lib/atoms/a/metadata.json
+++ b/lib/atoms/a/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "ln-a-a",
+  "description": "Atom - A Link",
+  "params": {
+    "link": "STRING",
+    "href": "STRING",
+    "target": "STRING",
+    "class": "STRING"
+  }
+}

--- a/lib/atoms/a/template.html
+++ b/lib/atoms/a/template.html
@@ -1,0 +1,1 @@
+<a ng-href="{{$ctrl.href}}" ng-class="$ctrl.class" ng-attr-target="{{$ctrl.target}}">{{$ctrl.link}}</a>

--- a/lib/atoms/a/template.html
+++ b/lib/atoms/a/template.html
@@ -1,1 +1,1 @@
-<a ng-href="{{$ctrl.href}}" ng-class="$ctrl.class" ng-attr-target="{{$ctrl.target}}">{{$ctrl.link}}</a>
+<a ng-href="{{$ctrl.href}}" ng-class="$ctrl.class" ng-attr-target="{{$ctrl.target}}">{{$ctrl.title}}</a>

--- a/lib/atoms/h1/template.html
+++ b/lib/atoms/h1/template.html
@@ -1,1 +1,1 @@
-<h1 ng-class="{{::class}}">{{::title}}</h1>
+<h1 ng-class="$ctrl.class">{{$ctrl.title}}</h1>

--- a/lib/atoms/h2/h2.component.js
+++ b/lib/atoms/h2/h2.component.js
@@ -1,14 +1,11 @@
-angular
-    .module('lnPatterns')
-    .component('lnAH2', lnAH2);
-
 var lnAH2 = {
-    restrict: 'E',
-    replace: true,
     templateUrl: 'lnPatterns/atoms/h2/template.html',
     bindings: {
-        title: '<',
-        class: '<'
+        title: '@',
+        class: '@'
     }
 };
 
+angular
+    .module('lnPatterns')
+    .component('lnAH2', lnAH2);

--- a/lib/atoms/h2/template.html
+++ b/lib/atoms/h2/template.html
@@ -1,1 +1,1 @@
-<h2 ng-class="{{::class}}">{{::title}}</h2>
+<h2 ng-class="$ctrl.class">{{$ctrl.title}}</h2>

--- a/lib/atoms/h3/example.html
+++ b/lib/atoms/h3/example.html
@@ -1,0 +1,1 @@
+<ln-a-h3 title="{{title}}" class="{{class}}"></ln-a-h3>

--- a/lib/atoms/h3/h3.component.js
+++ b/lib/atoms/h3/h3.component.js
@@ -1,5 +1,5 @@
-var lnAH1 = {
-    templateUrl: 'lnPatterns/atoms/h1/template.html',
+var lnAH3 = {
+    templateUrl: 'lnPatterns/atoms/h3/template.html',
     bindings: {
         title: '@',
         class: '@'
@@ -8,4 +8,4 @@ var lnAH1 = {
 
 angular
     .module('lnPatterns')
-    .component('lnAH1', lnAH1);
+    .component('lnAH3', lnAH3);

--- a/lib/atoms/h3/metadata.json
+++ b/lib/atoms/h3/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "ln-a-h3",
+  "description": "Atom - Header 3",
+  "params": {
+    "title": "STRING",
+    "class": "STRING"
+  }
+}

--- a/lib/atoms/h3/template.html
+++ b/lib/atoms/h3/template.html
@@ -1,0 +1,1 @@
+<h3 ng-class="$ctrl.class">{{$ctrl.title}}</h3>


### PR DESCRIPTION
- Changes to make patterns work with angular 1.5 components.
- Add base atoms for 'h3' and 'a' tags.
