### PR TITLE
Add ln prefix to all components' parameters to avoid html conflicts.

### DIFF
--- a/lib/atoms/a/a.component.js
+++ b/lib/atoms/a/a.component.js
@@ -1,10 +1,10 @@
 var lnAA = {
     templateUrl: 'lnPatterns/atoms/a/template.html',
     bindings: {
-        title: '@',
-        href: '@',
-        target: '@',
-        class: '@'
+        lnTitle: '@',
+        lnHref: '@',
+        lnTarget: '@',
+        lnClass: '@'
     }
 };
 

--- a/lib/atoms/a/example.html
+++ b/lib/atoms/a/example.html
@@ -1,1 +1,1 @@
-<ln-a-a title="{{title}}" href="{{href}}" target="{{target}}" class="{{class}}"></ln-a-a>
+<ln-a-a ln-title="{{lnTitle}}" ln-href="{{lnHref}}" ln-target="{{lnTarget}}" ln-class="{{lnClass}}"></ln-a-a>

--- a/lib/atoms/a/metadata.json
+++ b/lib/atoms/a/metadata.json
@@ -2,9 +2,9 @@
   "name": "ln-a-a",
   "description": "Atom - A Link",
   "params": {
-    "title": "STRING",
-    "href": "STRING",
-    "target": "STRING",
-    "class": "STRING"
+    "lnTitle": "STRING",
+    "lnTref": "STRING",
+    "lnTarget": "STRING",
+    "lnClass": "STRING"
   }
 }

--- a/lib/atoms/a/template.html
+++ b/lib/atoms/a/template.html
@@ -1,1 +1,1 @@
-<a ng-href="{{$ctrl.href}}" ng-class="$ctrl.class" ng-attr-target="{{$ctrl.target}}">{{$ctrl.title}}</a>
+<a ng-href="{{$ctrl.lnHref}}" ng-class="$ctrl.lnClass" ng-attr-target="{{$ctrl.lnTarget}}">{{$ctrl.lnTitle}}</a>

--- a/lib/atoms/h1/example.html
+++ b/lib/atoms/h1/example.html
@@ -1,1 +1,1 @@
-<ln-a-h1 title="{{title}}" class="{{class}}"></ln-a-h1>
+<ln-a-h1 ln-title="{{lnTitle}}" ln-class="{{lnClass}}"></ln-a-h1>

--- a/lib/atoms/h1/h1.component.js
+++ b/lib/atoms/h1/h1.component.js
@@ -1,8 +1,8 @@
 var lnAH1 = {
     templateUrl: 'lnPatterns/atoms/h1/template.html',
     bindings: {
-        title: '@',
-        class: '@'
+        lnTitle: '@',
+        lnClass: '@'
     }
 };
 

--- a/lib/atoms/h1/metadata.json
+++ b/lib/atoms/h1/metadata.json
@@ -2,7 +2,7 @@
   "name": "ln-a-h1",
   "description": "Atom - Header 1",
   "params": {
-    "title": "STRING",
-    "class": "STRING"
+    "lnTitle": "STRING",
+    "lnClass": "STRING"
   }
 }

--- a/lib/atoms/h1/template.html
+++ b/lib/atoms/h1/template.html
@@ -1,1 +1,1 @@
-<h1 ng-class="$ctrl.class">{{$ctrl.title}}</h1>
+<h1 ng-class="$ctrl.lnClass">{{$ctrl.lnTitle}}</h1>

--- a/lib/atoms/h2/example.html
+++ b/lib/atoms/h2/example.html
@@ -1,1 +1,1 @@
-<ln-a-h2 title="{{title}}" class="{{class}}"></ln-a-h2>
+<ln-a-h2 ln-title="{{lnTitle}}" ln-class="{{lnClass}}"></ln-a-h2>

--- a/lib/atoms/h2/h2.component.js
+++ b/lib/atoms/h2/h2.component.js
@@ -1,8 +1,8 @@
 var lnAH2 = {
     templateUrl: 'lnPatterns/atoms/h2/template.html',
     bindings: {
-        title: '@',
-        class: '@'
+        lnTitle: '@',
+        lnClass: '@'
     }
 };
 

--- a/lib/atoms/h2/metadata.json
+++ b/lib/atoms/h2/metadata.json
@@ -2,7 +2,7 @@
   "name": "ln-a-h2",
   "description": "Atom - Header 2",
   "params": {
-    "title": "STRING",
-    "class": "STRING"
+    "lnTitle": "STRING",
+    "lnClass": "STRING"
   }
 }

--- a/lib/atoms/h2/template.html
+++ b/lib/atoms/h2/template.html
@@ -1,1 +1,1 @@
-<h2 ng-class="$ctrl.class">{{$ctrl.title}}</h2>
+<h2 ng-class="$ctrl.lnClass">{{$ctrl.lnTitle}}</h2>

--- a/lib/atoms/h3/example.html
+++ b/lib/atoms/h3/example.html
@@ -1,1 +1,1 @@
-<ln-a-h3 title="{{title}}" class="{{class}}"></ln-a-h3>
+<ln-a-h3 ln-title="{{lnTitle}}" ln-class="{{lnClass}}"></ln-a-h3>

--- a/lib/atoms/h3/h3.component.js
+++ b/lib/atoms/h3/h3.component.js
@@ -1,8 +1,8 @@
 var lnAH3 = {
     templateUrl: 'lnPatterns/atoms/h3/template.html',
     bindings: {
-        title: '@',
-        class: '@'
+        lnTitle: '@',
+        lnClass: '@'
     }
 };
 

--- a/lib/atoms/h3/metadata.json
+++ b/lib/atoms/h3/metadata.json
@@ -2,7 +2,7 @@
   "name": "ln-a-h3",
   "description": "Atom - Header 3",
   "params": {
-    "title": "STRING",
-    "class": "STRING"
+    "lnTitle": "STRING",
+    "lnClass": "STRING"
   }
 }

--- a/lib/atoms/h3/template.html
+++ b/lib/atoms/h3/template.html
@@ -1,1 +1,1 @@
-<h3 ng-class="$ctrl.class">{{$ctrl.title}}</h3>
+<h3 ng-class="$ctrl.lnClass">{{$ctrl.lnTitle}}</h3>


### PR DESCRIPTION
Components with parameters which also are valid html attributes (class, id, name, etc) can generate conflicts, because we can not use "replace" option when using Angular 1.5 components (still valid for directives, but not for components). To avoid this situation, I added 'ln' prefix to all components' parameters.
