### PR TITLE
v0.1.9

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,11 +42,11 @@
         "props": false
       }
     ],
-    "complexity": [ 2, 3 ],
-    "max-depth": [2, 3],
-    "max-len": [1, 160, 4],
+    "complexity": [ 2, 10 ],
+    "max-depth": [2, 4],
+    "max-len": [1, 200, 4],
     "max-nested-callbacks": [2, 3],
-    "max-statements": [2, 20],
+    "max-statements": [2, 30],
     "new-cap": 2,
     "new-parens": 2,
     "no-negated-condition": 2,

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -43,22 +43,22 @@ rules:
      - 2
      -
        style: single
-   brace-style:
-     - 2
-     -
-       style: 1tbs
-       allow-single-line: false
-   empty-line-between-blocks:
-     - 2
-     -
-       include: true
-   space-after-colon: 2
-   space-after-bang: 2
-   space-after-comma: 2
-   space-around-operator: 2
-   space-before-brace: 2
-   space-before-colon: 2
-   space-between-parens: 2
-   trailing-semicolon: 2
-   url-quotes: 2
-   zero-unit: 2
+  brace-style:
+    - 2
+    -
+      style: 1tbs
+      allow-single-line: false
+  empty-line-between-blocks:
+    - 2
+    -
+      include: true
+  space-after-colon: 2
+  space-after-bang: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-brace: 2
+  space-before-colon: 2
+  space-between-parens: 2
+  trailing-semicolon: 2
+  url-quotes: 2
+  zero-unit: 2

--- a/lib/organisms/gravity-form/gravity-form.controller.js
+++ b/lib/organisms/gravity-form/gravity-form.controller.js
@@ -2,9 +2,9 @@ angular
   .module('lnPatterns')
   .controller('lnOGravityFormController', lnOGravityFormController);
 
-lnOGravityFormController.$inject = ['$log', '$scope', '$element', '$attrs', '$sce', 'lnOGravityFormService', 'lnOGravityValidationParser', 'lnOGravityFormDataParser'];
+lnOGravityFormController.$inject = ['$log', '$scope', '$element', '$attrs', '$sce', '$cookies', '$location', 'lnOGravityFormService', 'lnOGravityValidationParser', 'lnOGravityFormDataParser'];
 
-function lnOGravityFormController($log, $scope, $element, $attrs, $sce, lnOGravityFormService, lnOGravityValidationParser, lnOGravityFormDataParser) {
+function lnOGravityFormController($log, $scope, $element, $attrs, $sce, $cookies, $location, lnOGravityFormService, lnOGravityValidationParser, lnOGravityFormDataParser) {
   var FORM_INPUTS = ['input', 'textarea', 'select', 'datalist', 'keygen'];
   var vm = this;
   var inputs;
@@ -89,6 +89,34 @@ function lnOGravityFormController($log, $scope, $element, $attrs, $sce, lnOGravi
 
     if (vm.loadFromAPI) {
       vm.formSubmitted = true;
+    }
+
+    // manually set cookies because they are not being set by angular $http service
+    var confirmationMsg = response.data.response.confirmation_message;
+
+    if ( confirmationMsg && confirmationMsg.trim() !== '' ) {
+      var pattern = /<!--cookies:.*-->/;
+      var cookies = pattern.exec( confirmationMsg );
+
+      if ( cookies && cookies.length > 0 ) {
+        response.data.response.confirmation_message = confirmationMsg.replace( pattern, '' );
+        cookies = cookies[0].replace( '<!--cookies:', '' ).replace( '-->', '' );
+        cookies = angular.fromJson(cookies);
+
+        angular.forEach(cookies, function(cookie) {
+          var splitted = cookie.split( / |=|;/ );
+
+          if ( splitted.length > 2 ) {
+            var key = splitted[1];
+            var val = decodeURI(splitted[2]);
+            var domain = '.' + $location.host();
+
+            $cookies.put( key, val, {
+              domain: domain
+            } );
+          }
+        });
+      }
     }
 
     clearInputElements();

--- a/lib/organisms/gravity-form/parser.form-html.js
+++ b/lib/organisms/gravity-form/parser.form-html.js
@@ -102,7 +102,7 @@ function lnOGravityFormParser($log, isValidParameterFilter, isValidObjectAndProp
   function parsePages(data, formName) {
     var _html = '';
     var _currentPage;
-    var _pageFields;
+    var _pageData;
 
     var _numberOfPages = (isValidObjectAndPropertyFilter(data.pagination, 'pages'))
       ? data.pagination.pages.length

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-patternlab",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "An AngularJS module for Lean Patterns.",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "main": "index.js",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)

Cookies that are returned from the gforms submissions are not being stored on the browser by the angular's $http service.
- **What is the new behavior (if this is a feature change)?**

Manually store the cookies using the $cookies service.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No.
- **Other information**:
