### PR TITLE
Cached data to avoid multiple requests - Fix #83

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -39,7 +39,7 @@ rules:
     -
       properties:
         - content
-  quote:
+  quotes:
      - 2
      -
        style: single

--- a/lib/molecules/admin-bar/admin-bar.service.js
+++ b/lib/molecules/admin-bar/admin-bar.service.js
@@ -27,7 +27,7 @@ function lnMAdminBarService($rootScope, $q, $http) {
     var deferred = $q.defer();
     var options = {
       withCredentials: true,
-      cache: true,
+      cache: true
     };
 
     $http

--- a/lib/molecules/admin-bar/admin-bar.service.js
+++ b/lib/molecules/admin-bar/admin-bar.service.js
@@ -25,9 +25,13 @@ function lnMAdminBarService($rootScope, $q, $http) {
 
   function getAdminBarData() {
     var deferred = $q.defer();
+    var options = {
+      withCredentials: true,
+      cache: true,
+    };
 
     $http
-      .get(apiUrl, { withCredentials: true })
+      .get(apiUrl, options)
       .then(function (response) {
         return deferred.resolve(response);
       }, function (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-patternlab",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "An AngularJS module for Lean Patterns.",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "main": "index.js",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)

Explained here https://github.com/moxie-lean/ng-patternlab/issues/83
- **What is the new behavior (if this is a feature change)?**

By setting the cache it prevents other requests generated by the gravity forms component during the run and config part.

Cache is not persistent so it does not causes any issue for next loadings or in refresh. 
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No.
