### PR TITLE
Fix function for show inline style in text only.

### DIFF
--- a/lib/organisms/flexible-content/flexible-content.directive.js
+++ b/lib/organisms/flexible-content/flexible-content.directive.js
@@ -39,7 +39,7 @@ function lnOFlexibleContent($compile, $injector, $sanitize) {
             parAttr = prefix + parAttr;
           }
 
-          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key];
+          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].replace(/"/g, "'");
 
           rowDirective += ' ' + parAttr + '="' + value + '"';
         }

--- a/lib/organisms/flexible-content/flexible-content.directive.js
+++ b/lib/organisms/flexible-content/flexible-content.directive.js
@@ -39,7 +39,7 @@ function lnOFlexibleContent($compile, $injector, $sanitize) {
             parAttr = prefix + parAttr;
           }
 
-          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].replace(/"/g, "'");
+          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].replace(/"/g, '\'');
 
           rowDirective += ' ' + parAttr + '="' + value + '"';
         }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  You can add style inline to the api elements. 
- **What is the current behavior?** (You can also link to an open issue
  here)
  You can't  see in the frontend the element with style inline
- **What is the new behavior (if this is a feature change)?**

You can use style inline from the api
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
- **Other information**:
