### PR TITLE
Fix function for escape code in example of pattern.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,7 +209,7 @@ gulp.task('lnPatternsComponents', ['lnPatternsLoadConfig'], function (cb) {
             examples += exampleHtml
               .replace(/{EXAMPLE_ID}/g, exampleId)
               .replace(/{EXAMPLE_NAME}/g, exampleInstance.name)
-              .replace(/{EXAMPLE_PARAMS}/g, controllerAttrsPretty);
+              .replace(/{EXAMPLE_PARAMS}/g, _.escape(controllerAttrsPretty));
 
             controllers += controllerJs
               .replace(/{CONTROLLER_NAME}/g, controllerName)
@@ -258,7 +258,7 @@ gulp.task('lnPatternsComponents', ['lnPatternsLoadConfig'], function (cb) {
 
   var includeTemplate = function(file) {
     include(file, 'templates', customSearch);
-  }; 
+  };
 
   glob.sync('./lib/atoms/**/metadata.json').forEach(includeAtom);
   glob.sync('./lib/molecules/**/*.js').forEach(includeMolecule);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Fix when you use tag h2 for example in element  of the api 
- **What is the current behavior?** (You can also link to an open issue
  here)
  In the api example the text is render like normal page
  http://snaps.getmoxied.net/0Q180D0p403k
- **What is the new behavior (if this is a feature change)?**
  Remove the style inline and show only the tags and not render de page , and show only the code 
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
- **Other information**:
