### PR TITLE
Add fix when flexible content return something diferent to String.

### DIFF
--- a/lib/organisms/flexible-content/flexible-content.directive.js
+++ b/lib/organisms/flexible-content/flexible-content.directive.js
@@ -39,7 +39,7 @@ function lnOFlexibleContent($compile, $injector, $sanitize) {
             parAttr = prefix + parAttr;
           }
 
-          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].replace(/"/g, '\'');
+          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].toString().replace(/"/g, '\'');
 
           rowDirective += ' ' + parAttr + '="' + value + '"';
         }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Fix when the flexible content return one bolean element
- **What is the current behavior?** (You can also link to an open issue
  here)
  When return one bolean element don't show the content of the page
- **What is the new behavior (if this is a feature change)?**
  Convert the bolean to string and fix the problem
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
- **Other information**:
