### PR TITLE
Add if to check if $ is globally used

### DIFF
--- a/lib/organisms/gravity-form/gravity-form.controller.js
+++ b/lib/organisms/gravity-form/gravity-form.controller.js
@@ -54,19 +54,20 @@ function lnOGravityFormController($window, $log, $scope, $element, $attrs, $sce,
     if (response.data.isValid) {
       vm.form.name = response.data.formName;
       vm.form.id = response.data.formId;
-      vm.$scope.formHTML = $sce.trustAsHtml(response.data.html + response.data.confirmationHtml);
 
       if ($window.$) {
         vm.$scope.formHTML = response.data.html + response.data.confirmationHtml;
+      } else {
+        vm.$scope.formHTML = $sce.trustAsHtml(response.data.html + response.data.confirmationHtml);
       }
 
       validationBlocks = getValidationBlocks();
     } else {
       if ($window.$) {
         vm.$scope.formHTML = response.data.html;
+      } else {
+        vm.$scope.formHTML = $sce.trustAsHtml(response.data.html);
       }
-
-      vm.$scope.formHTML = $sce.trustAsHtml(response.data.html);
     }
   }
 

--- a/lib/organisms/gravity-form/gravity-form.controller.js
+++ b/lib/organisms/gravity-form/gravity-form.controller.js
@@ -62,13 +62,13 @@ function lnOGravityFormController($window, $log, $scope, $element, $attrs, $sce,
       }
 
       validationBlocks = getValidationBlocks();
+    } else if ($window.$) {
+      vm.$scope.formHTML = response.data.html;
     } else {
-      if ($window.$) {
-        vm.$scope.formHTML = response.data.html;
-      } else {
-        vm.$scope.formHTML = $sce.trustAsHtml(response.data.html);
-      }
+      vm.$scope.formHTML = $sce.trustAsHtml(response.data.html);
     }
+
+
   }
 
   function _cleanup() {

--- a/lib/organisms/gravity-form/gravity-form.controller.js
+++ b/lib/organisms/gravity-form/gravity-form.controller.js
@@ -2,14 +2,13 @@ angular
   .module('lnPatterns')
   .controller('lnOGravityFormController', lnOGravityFormController);
 
-lnOGravityFormController.$inject = ['$log', '$scope', '$element', '$attrs', '$sce', '$cookies', '$location', 'lnOGravityFormService', 'lnOGravityValidationParser', 'lnOGravityFormDataParser'];
+lnOGravityFormController.$inject = ['$window', '$log', '$scope', '$element', '$attrs', '$sce', '$cookies', '$location', 'lnOGravityFormService', 'lnOGravityValidationParser', 'lnOGravityFormDataParser'];
 
-function lnOGravityFormController($log, $scope, $element, $attrs, $sce, $cookies, $location, lnOGravityFormService, lnOGravityValidationParser, lnOGravityFormDataParser) {
+function lnOGravityFormController($window, $log, $scope, $element, $attrs, $sce, $cookies, $location, lnOGravityFormService, lnOGravityValidationParser, lnOGravityFormDataParser) {
   var FORM_INPUTS = ['input', 'textarea', 'select', 'datalist', 'keygen'];
   var vm = this;
   var inputs;
   var validationBlocks;
-
 
   // Public API
   //
@@ -56,8 +55,17 @@ function lnOGravityFormController($log, $scope, $element, $attrs, $sce, $cookies
       vm.form.name = response.data.formName;
       vm.form.id = response.data.formId;
       vm.$scope.formHTML = $sce.trustAsHtml(response.data.html + response.data.confirmationHtml);
+
+      if ($window.$) {
+        vm.$scope.formHTML = response.data.html + response.data.confirmationHtml;
+      }
+
       validationBlocks = getValidationBlocks();
     } else {
+      if ($window.$) {
+        vm.$scope.formHTML = response.data.html;
+      }
+
       vm.$scope.formHTML = $sce.trustAsHtml(response.data.html);
     }
   }

--- a/lib/organisms/gravity-form/gravity-form.directive.js
+++ b/lib/organisms/gravity-form/gravity-form.directive.js
@@ -30,8 +30,8 @@ function lnOGravityForm($compile) {
       var unbind = scope.$watch('formHTML', function (newHTML) {
         if (angular.isDefined(newHTML)) {
           var template = angular.element(newHTML);
-          
-          // If we are using jQuery as a global, we need to unrwap the HTML.
+
+          // If we are using jQuery as a global, we need to unwrap the HTML.
           if (window.$) {
             template = angular.element(newHTML.$$unwrapTrustedValue());
           }

--- a/lib/organisms/gravity-form/gravity-form.directive.js
+++ b/lib/organisms/gravity-form/gravity-form.directive.js
@@ -30,11 +30,6 @@ function lnOGravityForm($compile) {
       var unbind = scope.$watch('formHTML', function (newHTML) {
         if (angular.isDefined(newHTML)) {
           var template = angular.element(newHTML);
-
-          // If we are using jQuery as a global, we need to unwrap the HTML.
-          if (window.$) {
-            template = angular.element(newHTML.$$unwrapTrustedValue());
-          }
           element.html(template[0]);
           $compile(element.contents())(scope);
         }

--- a/lib/organisms/gravity-form/gravity-form.directive.js
+++ b/lib/organisms/gravity-form/gravity-form.directive.js
@@ -30,6 +30,11 @@ function lnOGravityForm($compile) {
       var unbind = scope.$watch('formHTML', function (newHTML) {
         if (angular.isDefined(newHTML)) {
           var template = angular.element(newHTML);
+          
+          // If we are using jQuery as a global, we need to unrwap the HTML.
+          if (window.$) {
+            template = angular.element(newHTML.$$unwrapTrustedValue());
+          }
           element.html(template[0]);
           $compile(element.contents())(scope);
         }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)
  If we want to use jQuery globally (to use an exernal plugin for example), gravity forms are not rendered
- **What is the new behavior (if this is a feature change)?**
  We check if we are using "$" variable in window, and render the html in a different way.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
