### PR TITLE
Fix parsing errors on objects with multiple HTML values

### DIFF
--- a/lib/organisms/flexible-content/flexible-content.directive.js
+++ b/lib/organisms/flexible-content/flexible-content.directive.js
@@ -2,9 +2,9 @@ angular
   .module('lnPatterns')
   .directive('lnOFlexibleContent', lnOFlexibleContent);
 
-lnOFlexibleContent.$inject = ['$compile', '$injector', '$sanitize'];
+lnOFlexibleContent.$inject = ['$compile', '$injector', '$sanitize', '$document'];
 
-function lnOFlexibleContent($compile, $injector, $sanitize) {
+function lnOFlexibleContent($compile, $injector, $sanitize, $document) {
   return {
     restrict: 'A',
     link: link,
@@ -39,7 +39,15 @@ function lnOFlexibleContent($compile, $injector, $sanitize) {
             parAttr = prefix + parAttr;
           }
 
-          var value = angular.isObject(row[key]) ? $sanitize(angular.toJson(row[key])) : row[key].toString().replace(/"/g, '\'');
+
+          var value = '';
+          if ( angular.isObject(row[key]) ) {
+            var div = $document[0].createElement('div');
+            div.appendChild( $document[0].createTextNode( angular.toJson(row[key])) );
+            value = $sanitize( div.innerHTML );
+          } else {
+            value = row[key].toString().replace(/"/g, '\'');
+          }
 
           rowDirective += ' ' + parAttr + '="' + value + '"';
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-patternlab",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "An AngularJS module for Lean Patterns.",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "main": "index.js",


### PR DESCRIPTION
In order to improve the sanitacion of values and prevent errors when the
markup uses multiple elements we use a virtual node to create a better
normalization process and make sure the sanitazion is done correctly.